### PR TITLE
Empty name error solved

### DIFF
--- a/src/Generate.jsx
+++ b/src/Generate.jsx
@@ -16,6 +16,8 @@ const Generate = () => {
       <h1>Generate Here</h1>
       <div className='form'>
         <input
+          required
+          pattern='([a-zA-Z]+\s*)+'
           type='text'
           placeholder='Enter Name'
           value={name}


### PR DESCRIPTION
This change resolves #5 by adding the pattern attribute in the input tag which inputs the name. The regular expression is given such that at least 1 letter must be entered in that input tag. Also the required attribute is given so that the input tag can't be empty.